### PR TITLE
Improve DGPAGE efficiency and reproducibility

### DIFF
--- a/man/compute_diversity_graph.Rd
+++ b/man/compute_diversity_graph.Rd
@@ -26,3 +26,8 @@ matrix \eqn{D} is:
 }
 where \eqn{\rho_i^+} and \eqn{\rho_i^-} follow Eqs. (5) and (6) \strong{but} with \eqn{q=0}.
 }
+\details{
+All pairwise distances are computed explicitly, leading to an
+\eqn{O(n^2)} algorithm. Large datasets may require a more efficient
+implementation.
+}

--- a/man/compute_similarity_graph.Rd
+++ b/man/compute_similarity_graph.Rd
@@ -29,3 +29,8 @@ matrix \eqn{S} is computed as:
 where \eqn{\tau_i^+} and \eqn{\tau_i^-} (Eqs. (5) and (6)) characterize the intra- and inter-class
 geometric distributions for sample \eqn{x_i}, respectively.
 }
+\details{
+This implementation materializes all pairwise distances and thus has
+\eqn{O(n^2)} computational complexity. For very large datasets you may
+want to implement a more efficient version, e.g., using Rcpp.
+}

--- a/man/dgpage_discriminant.Rd
+++ b/man/dgpage_discriminant.Rd
@@ -15,7 +15,8 @@ dgpage_discriminant(
   maxiter = 20,
   tol = 1e-05,
   verbose = TRUE,
-  q = 1.5
+  q = 1.5,
+  seed = NULL
 )
 }
 \arguments{
@@ -35,6 +36,8 @@ dgpage_discriminant(
 
 \item{q}{If \code{S} or \code{D} is \code{NULL}, we use \code{q} in
 \code{\link{compute_similarity_graph}}. Default 1.5.}
+
+\item{seed}{Optional seed passed to \code{dgpage_fit} for reproducibility.}
 }
 \value{
 An object of class \code{c("dgpage_projector","discriminant_projector","bi_projector",...)}

--- a/man/dgpage_fit.Rd
+++ b/man/dgpage_fit.Rd
@@ -13,7 +13,8 @@ dgpage_fit(
   beta = 1e-05,
   maxiter = 20,
   tol = 1e-05,
-  verbose = TRUE
+  verbose = TRUE,
+  seed = NULL
 )
 }
 \arguments{
@@ -35,6 +36,7 @@ dgpage_fit(
 \item{tol}{Convergence tolerance on the objective value.}
 
 \item{verbose}{Whether to print progress information.}
+\item{seed}{Optional integer seed controlling the random initialization.}
 }
 \value{
 A list with:


### PR DESCRIPTION
## Summary
- vectorize graph construction in `compute_similarity_graph()` and `compute_diversity_graph()`
- add optional `seed` argument to `dgpage_fit()` and `dgpage_discriminant()`
- use `RSpectra::eigs()` to solve the generalized eigenproblem
- compute pairwise matrix `E` without nested loops
- clarify docs and mention quadratic complexity

## Testing
- `R -q -e 'summary(1)'` *(fails: `bash: R: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68549ed05274832d82551118fbe226af