### PR TITLE
Improve gmmsd robustness and docs

### DIFF
--- a/R/gmmsd.R
+++ b/R/gmmsd.R
@@ -1,10 +1,11 @@
 #' Generalized Multiple Maximum Scatter Difference (GMMSD)
 #'
 #' This function implements the GMMSD method for feature extraction. It solves a
-#' generalized eigenvalue problem to find a projection that maximizes the difference
-#' between the between-class scatter and a scaled within-class scatter. The method
-#' uses a QR decomposition to enhance computational efficiency, making it suitable
-#' for high-dimensional data.
+#' symmetric generalized eigenvalue problem to find a projection that maximizes
+#' the difference between the between-class scatter and a scaled within-class
+#' scatter. The method uses a QR decomposition to enhance computational
+#' efficiency, making it suitable for high-dimensional data. The preprocessing
+#' object must come from the \pkg{multivarious} package.
 #'
 #' @param X A numeric matrix (n x d), where n is the number of samples (rows) and d
 #'          is the number of features (columns).
@@ -13,8 +14,8 @@
 #' @param c A numeric balance parameter scaling the within-class scatter matrix.
 #'          Typically a positive value. Default is 1.
 #' @param dim The number of dimensions (features) to retain in the transformed feature space.
-#' @param preproc A \code{pre_processor} object from \pkg{multivarious} (e.g. \code{center()}, \code{scale()}).
-#'                Defaults to \code{center()}.
+#' @param preproc A \code{pre_processor} object from \pkg{multivarious}
+#'   (e.g. \code{center()}, \code{scale()}). Defaults to \code{center()}.
 #'
 #' @return A \code{discriminant_projector} object (subclass can be \code{"gmmsd"}) containing:
 #' \itemize{
@@ -54,17 +55,14 @@ gmmsd <- function(X, y, c = 1, dim = 2, preproc = multivarious::center()) {
   
   # 2) Preprocessing step: center/scale/etc. if desired
   procres <- multivarious::prep(preproc)
-  Xp <- init_transform(procres, X)  # Xp is the preprocessed data (n x d)
-  
-  n <- nrow(Xp)
-  d <- ncol(Xp)
+  Xp <- multivarious::init_transform(procres, X)  # Xp is the preprocessed data (n x d)
   
   # 3) Mean-center check: Xp might already be centered by default if preproc=center().
   #    If your between_class_scatter() / within_class_scatter() do not handle
   #    centering internally, then pass Xp as is:
   
-  # 4) Use QR decomposition on t(Xp). 
-  #    If n >= d, qr.Q(...) yields a (d x d) orthonormal basis.
+  # 4) Use QR decomposition on t(Xp). If n >= d, qr.Q(...) yields a (d x d)
+  #    orthonormal basis.
   qr.decomp <- qr(t(Xp))
   Q1 <- qr.Q(qr.decomp)  # d x d
   
@@ -75,16 +73,17 @@ gmmsd <- function(X, y, c = 1, dim = 2, preproc = multivarious::center()) {
   # 6) Form M = Q1^T (Sb - c * Sw) Q1
   M <- t(Q1) %*% (Sb - c * Sw) %*% Q1
   
-  # 7) Solve eigenvalue problem
-  eigres <- eigen(M)
+  # 7) Solve eigenvalue problem (M is symmetric by construction)
+  eigres <- eigen(M, symmetric = TRUE)
+  if (dim > ncol(Q1)) {
+    stop("dim exceeds available dimensions")
+  }
   # By default eigen() returns eigenvalues in decreasing order.
   # We'll take the top 'dim' eigenvectors
   W <- Q1 %*% eigres$vectors[, 1:dim, drop = FALSE]  # shape (d x dim)
   
-  # 8) Project the data: W^T * X^T => shape (dim x n)
-  # We'll get s as (n x dim) by transposing again
-  transformed <- t(W) %*% t(Xp)     # (dim x n)
-  s <- t(transformed)               # (n x dim)
+  # 8) Project the data: Xp %*% W gives an (n x dim) matrix of scores
+  s <- Xp %*% W
   
   # 9) Build the discriminant_projector
   #    v = W (d x dim)

--- a/man/gmmsd.Rd
+++ b/man/gmmsd.Rd
@@ -18,8 +18,8 @@ Typically a positive value. Default is 1.}
 
 \item{dim}{The number of dimensions (features) to retain in the transformed feature space.}
 
-\item{preproc}{A \code{pre_processor} object from \pkg{multivarious} (e.g. \code{center()}, \code{scale()}).
-Defaults to \code{center()}.}
+\item{preproc}{A \code{pre_processor} object from \pkg{multivarious}
+(e.g. \code{center()}, \code{scale()}). Defaults to \code{center()}.}
 }
 \value{
 A \code{discriminant_projector} object (subclass can be \code{"gmmsd"}) containing:
@@ -33,10 +33,11 @@ A \code{discriminant_projector} object (subclass can be \code{"gmmsd"}) containi
 }
 \description{
 This function implements the GMMSD method for feature extraction. It solves a
-generalized eigenvalue problem to find a projection that maximizes the difference
-between the between-class scatter and a scaled within-class scatter. The method
-uses a QR decomposition to enhance computational efficiency, making it suitable
-for high-dimensional data.
+symmetric generalized eigenvalue problem to find a projection that maximizes the
+difference between the between-class scatter and a scaled within-class scatter.
+The method uses a QR decomposition to enhance computational efficiency, making it
+suitable for high-dimensional data. The preprocessing object must come from the
+\pkg{multivarious} package.
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
## Summary
- improve GMMSD documentation with details about symmetric eigenproblem
- use multivarious::init_transform and symmetric eigen solve
- check requested dimension against QR basis size
- simplify score computation

## Testing
- `R` commands were attempted but `R` is not installed in the environment


------
https://chatgpt.com/codex/tasks/task_e_68549f33b26c832dac9a24493fe083f9