### PR TITLE
Implement compute_Htdiff helper and improve fastolda

### DIFF
--- a/man/fastolda.Rd
+++ b/man/fastolda.Rd
@@ -32,3 +32,9 @@ Perform a fast Orthogonal Linear Discriminant Analysis (OLDA) based on provided 
 This function performs OLDA by pre-processing the data, computing difference-based scatter matrices, and then solving for a discriminant projection.
 The final result is returned as a \code{discriminant_projector} object from the \code{multivarious} package.
 }
+\examples{
+data(iris)
+X <- as.matrix(iris[, 1:4])
+Y <- iris[, 5]
+res <- fastolda(X, Y)
+}


### PR DESCRIPTION
## Summary
- implement `compute_Htdiff` helper in **fast_olda.R**
- regularize scatter matrix in `fastolda`
- validate `Y` length against `HT`
- expand documentation and add example

## Testing
- `R CMD build .` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68549f0ee9bc832dbb739a5eeeecc44f